### PR TITLE
fix: stop using nginx variable not to specify resolver

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -9,10 +9,8 @@ http {
     root /usr/share/nginx/html;
     index index.html;
 
-    set $domain_env $DOMAIN;
-
     location /api {
-      proxy_pass http://$domain_env:4000/;
+      proxy_pass http://$DOMAIN:4000/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Fix error below.

basicApp-web     | 2025/03/01 14:35:51 [error] 9#9: *1 no resolver defined to resolve basic-app-app, client: 172.22.0.1, server: , request: "GET /api HTTP/1.1", host: "localhost", referrer: "http://localhost/"

nginx の変数（$domain_env）が使われていると DNS を明示しないといけないらしい。
ということでこれを使わない形に修正した。